### PR TITLE
Keep the Flutter web app out of the search index

### DIFF
--- a/flutter/web/index.html
+++ b/flutter/web/index.html
@@ -18,7 +18,19 @@
 
     <meta charset="UTF-8" />
     <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
-    <meta name="description" content="A new Flutter project." />
+    <meta name="description" content="The DevToDollars app. Sign in to manage your account and subscription." />
+
+    <!--
+      This is the authenticated app, not a marketing surface. It targets no
+      keyword and there is nothing here for a search result to usefully show.
+      Flutter also renders into canvas at runtime, so a crawler only ever sees
+      this empty shell.
+
+      Crawling stays permitted on purpose. Google has to be able to fetch the
+      page to read this noindex; blocking it in robots.txt first would strand
+      the URL in the index as a "no information available" result.
+    -->
+    <meta name="robots" content="noindex, follow" />
 
     <!-- iOS meta tags & icons -->
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/flutter/web/robots.txt
+++ b/flutter/web/robots.txt
@@ -1,0 +1,10 @@
+# The netlify.toml catch-all rewrites every unmatched path to the app shell with
+# a 200, so without a real file here /robots.txt served HTML instead of rules.
+# Netlify serves static files before applying redirects, so this file escapes it.
+
+# Crawling is deliberately allowed. Every path on this host returns the same
+# shell, which carries <meta name="robots" content="noindex">, and Google has to
+# be able to fetch the page to see that tag. Disallowing here would block the
+# crawl and leave already-indexed URLs stranded in the index with no snippet.
+User-agent: *
+Allow: /


### PR DESCRIPTION
app.devtodollars.com is the authenticated app: auth, home, payments. It targets no keyword, owns no content cluster, and there is nothing in it a search result could usefully show. It was nonetheless being crawled and audited alongside the marketing site.

Ahrefs flagged it for having no outgoing links. That is not fixable and not really the problem: Flutter renders into canvas at runtime, so the served HTML is a bootstrap shell with no anchors in it by construction. The right answer is to stop asking a crawler to evaluate it, not to bolt links onto the shell.

Two things actually worth fixing were sitting underneath that flag:

- The netlify.toml catch-all rewrites every unmatched path to the app shell with a 200, so /robots.txt returned HTML and any invented URL returned an identical 200 page. Add a real robots.txt; Netlify serves static files ahead of redirect rules, so it escapes the catch-all.
- The production meta description was still Flutter's "A new Flutter project." placeholder.

Crawling is left allowed on purpose. Google has to fetch the page to read the noindex, so disallowing first would strand already-indexed URLs in the index with no snippet. Once they drop out, a Disallow can be added.

Not verified by a build: the local Flutter is 2.2.3 and this project needs Dart
>=3.2.3 (CI uses 3.22.2). netlify.toml already ships from the same web/ directory
and its rules are live in production, so robots.txt will deploy the same way.